### PR TITLE
Fix typo in requestHandlers.js

### DIFF
--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -7,7 +7,7 @@ module.exports.storeJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }
@@ -18,7 +18,7 @@ module.exports.getJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }


### PR DESCRIPTION
Corrected 'consol.elog' to 'console.log' in server/requestHandlers.js to ensure error messages are logged correctly.