### PR TITLE
Implement Analytics Tracking for Job Board and Interview Scheduling

### DIFF
--- a/client/src/components/InterviewTab.js
+++ b/client/src/components/InterviewTab.js
@@ -1,9 +1,9 @@
 import React, { PropTypes, Component } from 'react';
-
 import DatePicker from 'material-ui/DatePicker';
 import TimePicker from 'material-ui/TimePicker';
 import RaisedButton from 'material-ui/RaisedButton';
 import axios from 'axios';
+import Analytics from '../../utils/analytics';
 
 export default class InterviewTab extends Component {
   constructor(props) {
@@ -28,18 +28,21 @@ export default class InterviewTab extends Component {
   }
 
   submitInterviewTime () {
+    Analytics.trackEvent('Interview Scheduled', {
+      date: this.state.interviewDate,
+      time: this.state.interviewTime,
+      timestamp: new Date()
+    });
+
     console.log('submitting interview time');
     console.log('interviewDate: ', this.state.interviewDate);
     console.log('interviewTime: ', this.state.interviewTime);
-    // add a day
+
     const {interviewDate, interviewTime} = this.state;
     interviewDate.setDate(interviewDate.getDate() - 1);
-    // Add 1 week to date
+
     var followUpDate = new Date();
     followUpDate.setDate(interviewDate.getDate() + 5);
-
-    // Reminder date is 1 day after
-    // console.log('reminderDate: ', reminderDate);
 
     axios.post('/setReminder', {
       reminderDate: interviewDate,
@@ -47,7 +50,6 @@ export default class InterviewTab extends Component {
       followUpDate: followUpDate
     })
     .then(function (response) {
-      // TODO: Show snackbar as confirmation of reminder
       console.log(response);
     })
     .catch(function (error) {

--- a/client/src/components/JobBoard/Board.js
+++ b/client/src/components/JobBoard/Board.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ListCardContainer from './ListCardContainer';
 import util from '../../../lib/util';
+import Analytics from '../../utils/analytics';
 
 export default class Board extends React.Component {
   static propTypes = {
@@ -56,10 +57,15 @@ export default class Board extends React.Component {
   }
 
   componentWillMount() {
+    Analytics.trackEvent('JobBoard Viewed', { timestamp: new Date() });
     return util.fetchJobPosting()
     .then( result => { 
       this.setState({ list: result }) 
     });
+  }
+
+  handleCardClick(card) {
+    Analytics.trackEvent('JobCard Clicked', { card, timestamp: new Date() });
   }
 
   render() {    
@@ -70,7 +76,9 @@ export default class Board extends React.Component {
           key={Math.floor(Math.random()*100)} 
           id={Math.floor(Math.random()*100)} 
           list={listcontainer.cards} 
-          header={listcontainer.header}/>
+          header={listcontainer.header}
+          onCardClick={this.handleCardClick.bind(this)}
+        />
       ))}
       </div>
     );

--- a/client/src/utils/analytics.js
+++ b/client/src/utils/analytics.js
@@ -1,0 +1,9 @@
+// Hypothetical Analytics Utility
+
+class Analytics {
+    static trackEvent(eventName, eventDetails) {
+        console.log(`Event: ${eventName}`, eventDetails);
+    }
+}
+
+export default Analytics;


### PR DESCRIPTION
Added analytics tracking for user interactions with the job board and interview scheduling features.
- Created a utility for analytics tracking.
- Added tracking to job board when viewed and when job cards are clicked.
- Added tracking to interview scheduling when an interview is submitted.