### PR TITLE
Remove Hardcoded API Keys from server.js

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -127,7 +127,7 @@ app.post('/setReminder', function (req, res) {
     url: 'https://api.sparkpost.com/api/v1/transmissions',
     headers: {
       'content-type': 'application/json',
-      'authorization': '0526b81c29cb593ff22fd28413a1e139eedbb0ac'
+      'authorization': process.env.SPARKPOST_API_KEY
     },
     data: {
       "options":{"open_tracking":true,"click_tracking":true,"start_time": thankYouTime},
@@ -165,7 +165,7 @@ app.post('/setReminder', function (req, res) {
     url: 'https://api.sparkpost.com/api/v1/transmissions',
     headers: {
       'content-type': 'application/json',
-      'authorization': '0526b81c29cb593ff22fd28413a1e139eedbb0ac'
+      'authorization': process.env.SPARKPOST_API_KEY
     },
     data: {
       "options":{"open_tracking":true,"click_tracking":true,"start_time": followUpTime},


### PR DESCRIPTION
Replaced hardcoded SparkPost API key with an environment variable (SPARKPOST_API_KEY) to enhance security. Updated `server.js` to utilize the variable from the environment. Ensure to set SPARKPOST_API_KEY in your environment before running the server.