### PR TITLE
Add analytics events for job entry and interview submission

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -1,6 +1,7 @@
 export const FETCH_ENTRY = 'FETCH_ENTRY';
 export const ENTRY_SELECTED = 'ENTRY_SELECTED';
 export const FETCH_MEDIA = 'FETCH_MEDIA';
+export const ANALYTICS_EVENT = 'ANALYTICS_EVENT';
 
 export function fetchEntry(entries) {
   return {
@@ -20,5 +21,12 @@ export function fetchMedia(url) {
   return {
     type: FETCH_MEDIA,
     payload: url
+  };
+}
+
+export function analyticsEvent(eventName, data = {}) {
+  return {
+    type: ANALYTICS_EVENT,
+    payload: { eventName, data }
   };
 }

--- a/client/src/components/InterviewTab.js
+++ b/client/src/components/InterviewTab.js
@@ -1,11 +1,12 @@
 import React, { PropTypes, Component } from 'react';
-
+import { connect } from 'react-redux';
 import DatePicker from 'material-ui/DatePicker';
 import TimePicker from 'material-ui/TimePicker';
 import RaisedButton from 'material-ui/RaisedButton';
 import axios from 'axios';
+import { analyticsEvent } from '../actions/index';
 
-export default class InterviewTab extends Component {
+class InterviewTab extends Component {
   constructor(props) {
       super(props);
 
@@ -31,24 +32,19 @@ export default class InterviewTab extends Component {
     console.log('submitting interview time');
     console.log('interviewDate: ', this.state.interviewDate);
     console.log('interviewTime: ', this.state.interviewTime);
-    // add a day
     const {interviewDate, interviewTime} = this.state;
     interviewDate.setDate(interviewDate.getDate() - 1);
-    // Add 1 week to date
     var followUpDate = new Date();
     followUpDate.setDate(interviewDate.getDate() + 5);
-
-    // Reminder date is 1 day after
-    // console.log('reminderDate: ', reminderDate);
 
     axios.post('/setReminder', {
       reminderDate: interviewDate,
       reminderTime: interviewTime,
       followUpDate: followUpDate
     })
-    .then(function (response) {
-      // TODO: Show snackbar as confirmation of reminder
+    .then((response) => {
       console.log(response);
+      this.props.dispatch(analyticsEvent('INTERVIEW_TIME_SUBMITTED', { interviewDate, interviewTime }));
     })
     .catch(function (error) {
       console.log(error);
@@ -74,3 +70,5 @@ export default class InterviewTab extends Component {
     );
   }
 }
+
+export default connect()(InterviewTab);

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,12 +1,14 @@
 import React, { PropTypes, Component } from 'react';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
+import { connect } from 'react-redux';
+import { analyticsEvent } from '../actions/index';
 
 const customContentStyle = {
   maxWidth: 600,
 };
 
-export default class JobEntry extends Component {
+class JobEntry extends Component {
   constructor(props) {
     super(props);
     // TODO: Rename state to avoid duplication with JobEntry.jsx
@@ -34,15 +36,15 @@ export default class JobEntry extends Component {
     this.onNewJobPostingSave = this.onNewJobPostingSave.bind(this);
   }
 
-	// TODO: Rename handleOpen and handleClose functions to avoid duplication with JobEntry.jsx
-	handleOpen = () => {
-		this.setState({ open: true });
-	};
+  // TODO: Rename handleOpen and handleClose functions to avoid duplication with JobEntry.jsx
+  handleOpen = () => {
+    this.setState({ open: true });
+  };
 
-	handleClose = (e) => {
+  handleClose = (e) => {
     e.preventDefault();
-		this.props.handleDialog();
-	}
+    this.props.handleDialog();
+  }
 
   handleBoardName = (e) => { this.setState({ boardName: e.target.value }) };
   handleCompanyNameChange = (e) => { this.setState({ companyName: e.target.value }) };
@@ -55,13 +57,14 @@ export default class JobEntry extends Component {
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
+    const { boardName, companyName, jobTitle, jobUrl } = this.state;
     util.submitNewJobPosting(this.state);
+    this.props.dispatch(analyticsEvent('JOB_ENTRY_SUBMITTED', { boardName, companyName, jobTitle, jobUrl }));
   }
 
   render() {
     const {open , handleDialog} = this.props;
     const actions = [
-			// TODO: Consider to take out cancel, or click shaded area to cancel
       <FlatButton
         label="Save"
         primary={true}
@@ -151,3 +154,5 @@ export default class JobEntry extends Component {
     )
   }  
 }
+
+export default connect()(JobEntry);


### PR DESCRIPTION
This PR adds analytics event tracking for key user actions:

- Job Entry Submission: Dispatches an analytics event when a job entry is submitted.
- Interview Time Submission: Dispatches an analytics event when an interview time is submitted.

These changes help in tracking user interactions and understanding usage patterns better.

### Files Modified:
- `client/src/actions/index.js` - Added `ANALYTICS_EVENT` action.
- `client/src/components/JobEntry.js` - Dispatches analytics event on job submission.
- `client/src/components/InterviewTab.js` - Dispatches analytics event on interview time submission.

Please review and merge. Thank you!