### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/components/Call.js
+++ b/client/src/components/Call.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import RaisedButton from 'material-ui/RaisedButton';
 import VoiceRecognition from './VoiceRecognition';
@@ -8,7 +9,7 @@ import EntryList from '../containers/entry-list/EntryList';
 
 export default class Call extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string,
+    name: PropTypes.string,
   };
 
   constructor(props) {

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom'
 
 import AppBar from 'material-ui/AppBar';
@@ -7,7 +8,7 @@ import MenuItem from 'material-ui/MenuItem';
 
 export default class Header extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string,
+    name: PropTypes.string,
   };
 
   constructor(props) {

--- a/client/src/components/InterviewTab.js
+++ b/client/src/components/InterviewTab.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
 
 import DatePicker from 'material-ui/DatePicker';
 import TimePicker from 'material-ui/TimePicker';

--- a/client/src/components/JobBoard/Board.js
+++ b/client/src/components/JobBoard/Board.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ListCardContainer from './ListCardContainer';
 import util from '../../../lib/util';
 
 export default class Board extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string,
+    name: PropTypes.string,
   };
 
   constructor(props) {

--- a/client/src/components/JobBoard/Card.js
+++ b/client/src/components/JobBoard/Card.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
@@ -12,6 +13,17 @@ class Card extends Component {
     this.state = {open: false};
     this.handleDialog = this.handleDialog.bind(this);
   }
+
+  static propTypes = {
+    card: PropTypes.object.isRequired,
+    isDragging: PropTypes.bool.isRequired,
+    connectDragSource: PropTypes.func.isRequired,
+    connectDropTarget: PropTypes.func.isRequired,
+    index: PropTypes.number.isRequired,
+    listId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    removeCard: PropTypes.func.isRequired,
+    moveCard: PropTypes.func.isRequired,
+  };
 
   handleDialog() {
     console.log('handle toggleed');

--- a/client/src/components/JobCard.js
+++ b/client/src/components/JobCard.js
@@ -1,19 +1,21 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import JobInfo from './JobInfo';
 import { FlatButton, RaisedButton, Dialog } from 'material-ui';
 // import sample from '../../../database/sampleData.js';
 
 import InterviewTab from './InterviewTab';
 
-const propTypes = {
-
-};
-
 const customContentStyle = {
   maxWidth: 600,
 };
 
 export default class JobCard extends Component {
+	static propTypes = {
+		open: PropTypes.bool.isRequired,
+		card: PropTypes.object.isRequired,
+		handleDialog: PropTypes.func.isRequired,
+	};
 	// TODO: Rename state to avoid duplication with JobEntry.jsx
 	state = {
 		open: false,

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
 
@@ -7,6 +8,11 @@ const customContentStyle = {
 };
 
 export default class JobEntry extends Component {
+  static propTypes = {
+    handleDialog: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired,
+  };
+
   constructor(props) {
     super(props);
     // TODO: Rename state to avoid duplication with JobEntry.jsx

--- a/client/src/components/JobInfo.js
+++ b/client/src/components/JobInfo.js
@@ -1,9 +1,5 @@
-import React, { PropTypes, Component } from 'react';
-import Dialog from 'material-ui/Dialog';
-
-const propTypes = {
-  card: PropTypes.object.isRequired,
-};
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const JobInfo = ({card}) => {
   return (
@@ -23,5 +19,9 @@ const JobInfo = ({card}) => {
     </div>
   )
 }
+
+JobInfo.propTypes = {
+  card: PropTypes.object.isRequired,
+};
 
 export default JobInfo;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
+import PropTypes from 'prop-types'
 
 /* * Utils * */
 import 'react-hot-loader/patch'
@@ -20,7 +21,7 @@ const consoleErrorReporter = ({error}) => {
 }
 
 consoleErrorReporter.propTypes = {
-  error: React.PropTypes.instanceOf(Error).isRequired
+  error: PropTypes.instanceOf(Error).isRequired
 }
 
 /* * wrapping App.js in Proivder component to allow access to our redux store * */


### PR DESCRIPTION
Summary:

**PropTypes Fixes**
- Swapped the console error reporter over to the standalone `prop-types` package to eliminate the deprecated `React.PropTypes` usage (`client/src/index.js:4`, `client/src/index.js:24`).
- Updated the job detail components to import `PropTypes` correctly and defined the props they expect so type errors surface early (`client/src/components/JobCard.js:14`, `client/src/components/JobEntry.js:10`, `client/src/components/JobInfo.js:23`).
- Brought the rest of the UI components in line with the new prop-types import path and removed the now-unused `PropTypes` grab in the interview tab (`client/src/components/JobBoard/Card.js:1`, `client/src/components/JobBoard/Card.js:17`, `client/src/components/Header.js:1`, `client/src/components/Call.js:1`, `client/src/components/JobBoard/Board.js:1`, `client/src/components/InterviewTab.js:1`).

Tests: not run (npm dependencies aren’t installed in this environment).

Next steps: 1) Install dependencies with `npm install` if needed. 2) Run your preferred lint/build command (e.g., `npm run lint` or `npm run build`) to double-check everything compiles cleanly.