### PR TITLE
Changes from Codex

### DIFF
--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -7,7 +7,7 @@ module.exports.storeJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }
@@ -18,7 +18,7 @@ module.exports.getJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }


### PR DESCRIPTION
Summary:

Replaced the typoed logger with the standard call so both handlers now emit errors via `console.log` in `server/requestHandlers.js:9` and `server/requestHandlers.js:19`. Consider running your usual server start script to confirm the handlers log correctly during error cases.