### PR TITLE
Changes from Codex

### DIFF
--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -7,7 +7,7 @@ module.exports.storeJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }
@@ -18,7 +18,7 @@ module.exports.getJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }


### PR DESCRIPTION
Summary:

Replaced the typo’d `consol.elog` calls with `console.log` in `server/requestHandlers.js:11` and `server/requestHandlers.js:23` so errors from the job posting handlers are actually logged.

I didn’t run tests; if you want extra assurance, you could 1) hit the failing endpoints to confirm the log shows up, or 2) run your existing test suite.