### PR TITLE
Changes from Codex

### DIFF
--- a/client/lib/analytics.js
+++ b/client/lib/analytics.js
@@ -1,0 +1,69 @@
+const isAnalyticsAvailable = () => (
+  typeof window !== 'undefined' &&
+  window.analytics &&
+  typeof window.analytics.track === 'function'
+);
+
+const isProduction = () => (
+  typeof process !== 'undefined' &&
+  process.env &&
+  process.env.NODE_ENV === 'production'
+);
+
+const logFallback = (eventName, payload) => {
+  if (typeof console !== 'undefined' && console.info && !isProduction()) {
+    console.info(`[analytics] ${eventName}`, payload);
+  }
+};
+
+const track = (eventName, payload = {}) => {
+  if (isAnalyticsAvailable()) {
+    window.analytics.track(eventName, payload);
+  } else {
+    logFallback(eventName, payload);
+  }
+};
+
+const sanitizeJobDetails = (details = {}) => {
+  const {
+    boardName = null,
+    companyName = null,
+    jobTitle = null,
+    location = null,
+  } = details;
+
+  return { boardName, companyName, jobTitle, location };
+};
+
+const trackJobPostingFlowOpened = (details) => (
+  track('Job Posting Creation Opened', sanitizeJobDetails(details))
+);
+
+const trackJobPostingFlowSubmitted = (details) => (
+  track('Job Posting Creation Submitted', sanitizeJobDetails(details))
+);
+
+const trackJobPostingFlowSucceeded = (details) => (
+  track('Job Posting Creation Succeeded', sanitizeJobDetails(details))
+);
+
+const trackJobPostingFlowFailed = (error, details) => {
+  const payload = Object.assign({
+    message: error && error.message ? error.message : 'Unknown error',
+  }, sanitizeJobDetails(details));
+
+  track('Job Posting Creation Failed', payload);
+};
+
+const trackJobPostingFlowCancelled = (details) => (
+  track('Job Posting Creation Cancelled', sanitizeJobDetails(details))
+);
+
+export default {
+  track,
+  trackJobPostingFlowOpened,
+  trackJobPostingFlowSubmitted,
+  trackJobPostingFlowSucceeded,
+  trackJobPostingFlowFailed,
+  trackJobPostingFlowCancelled,
+};

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
+import analytics from '../../lib/analytics';
 
 const customContentStyle = {
   maxWidth: 600,
@@ -31,7 +32,6 @@ export default class JobEntry extends Component {
     this.handlePreferredQualificationsChange = this.handlePreferredQualificationsChange.bind(this);
     this.handleLocationChange = this.handleLocationChange.bind(this);
     this.handleJobUrlChange = this.handleJobUrlChange.bind(this);
-    this.onNewJobPostingSave = this.onNewJobPostingSave.bind(this);
   }
 
 	// TODO: Rename handleOpen and handleClose functions to avoid duplication with JobEntry.jsx
@@ -39,10 +39,23 @@ export default class JobEntry extends Component {
 		this.setState({ open: true });
 	};
 
-	handleClose = (e) => {
-    e.preventDefault();
+	handleClose = (e, reason = 'cancel') => {
+    if (e && typeof e.preventDefault === 'function') {
+      e.preventDefault();
+    }
+
+    if (reason === 'cancel') {
+      analytics.trackJobPostingFlowCancelled(this.getJobDetails());
+    }
+
 		this.props.handleDialog();
 	}
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open) {
+      analytics.trackJobPostingFlowOpened(this.getJobDetails());
+    }
+  }
 
   handleBoardName = (e) => { this.setState({ boardName: e.target.value }) };
   handleCompanyNameChange = (e) => { this.setState({ companyName: e.target.value }) };
@@ -53,27 +66,67 @@ export default class JobEntry extends Component {
   handleLocationChange = (e) => { this.setState({ location: e.target.value }) };
   handleJobUrlChange = (e) => { this.setState({ jobUrl: e.target.value }) };
   
-  onNewJobPostingSave = (e) => {
-    e.preventDefault();
-    util.submitNewJobPosting(this.state);
+  getJobDetails = () => {
+    const {
+      boardName,
+      companyName,
+      jobTitle,
+      jobDescription,
+      basicQualifications,
+      preferredQualifications,
+      location,
+      jobUrl,
+    } = this.state;
+
+    return {
+      boardName,
+      companyName,
+      jobTitle,
+      jobDescription,
+      basicQualifications,
+      preferredQualifications,
+      location,
+      jobUrl,
+    };
+  };
+
+  onNewJobPostingSave = () => {
+    const jobDetails = this.getJobDetails();
+
+    analytics.trackJobPostingFlowSubmitted(jobDetails);
+
+    return util.submitNewJobPosting(jobDetails)
+      .then(() => analytics.trackJobPostingFlowSucceeded(jobDetails))
+      .catch((error) => {
+        analytics.trackJobPostingFlowFailed(error, jobDetails);
+        throw error;
+      });
+  }
+
+  handleSave = (e) => {
+    if (e && typeof e.preventDefault === 'function') {
+      e.preventDefault();
+    }
+
+    const submission = this.onNewJobPostingSave();
+    this.handleClose(null, 'save');
+
+    return submission;
   }
 
   render() {
-    const {open , handleDialog} = this.props;
+    const { open } = this.props;
     const actions = [
 			// TODO: Consider to take out cancel, or click shaded area to cancel
       <FlatButton
         label="Save"
         primary={true}
-        onTouchTap={(e) => {
-         this.handleClose(e);
-         this.onNewJobPostingSave(e);
-        }}
+        onTouchTap={this.handleSave}
       />,
       <FlatButton
         label="Cancel"
         primary={true}
-        onTouchTap={handleDialog}
+        onTouchTap={(e) => this.handleClose(e, 'cancel')}
       />,
     ];
     return (


### PR DESCRIPTION
Summary:

Instrumented analytics around the job posting form to capture engagement signals.

- `client/lib/analytics.js:1` Added a reusable analytics helper that wraps `window.analytics.track`, guards against missing providers, provides a dev-only console fallback, and sanitizes job metadata before emitting events.
- `client/src/components/JobEntry.js:42` Hooked the dialog lifecycle (open, cancel, submit) into the analytics helper, refactored payload gathering for reuse, and now track submission success/failure without altering existing UI behavior.

- Tests: not run (no automated suite specified).

1. Trigger the job posting flow in a staging/dev build to confirm the new events arrive in your analytics dashboard.