### PR TITLE
Changes from Codex

### DIFF
--- a/client/lib/analytics.js
+++ b/client/lib/analytics.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const trackEvent = (name, data = {}) => {
+  if (!name) {
+    return Promise.resolve();
+  }
+
+  const payload = {
+    name,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+
+  return axios.post('/analytics/events', payload).catch((err) => {
+    /* eslint-disable no-console */
+    console.error('Analytics event failed to send', err);
+    /* eslint-enable no-console */
+  });
+};
+
+export default {
+  trackEvent,
+};

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -5,6 +5,7 @@ import { DragDropContext } from 'react-dnd';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import reducers from '../reducers'
+import analytics from '../../lib/analytics';
 
 import Header from './Header'
 import Home from './Home'
@@ -38,9 +39,17 @@ class App extends Component {
   componentWillMount () {
   }
 
-  handleDialog() {
+  handleDialog(reason = 'unknown') {
+    const willOpen = !this.state.open;
+
+    if (willOpen) {
+      analytics.trackEvent('job_posting_modal_opened', { trigger: reason });
+    } else {
+      analytics.trackEvent('job_posting_modal_closed', { trigger: reason });
+    }
+
     this.setState({
-      open: !this.state.open 
+      open: willOpen,
     });
   }
 
@@ -54,7 +63,7 @@ class App extends Component {
               <FloatingActionButton 
                 secondary={true} 
                 style={style}
-                onTouchTap={this.handleDialog}
+                onTouchTap={() => this.handleDialog('floating_action_button')}
                 >
                 <ContentAdd />
               </FloatingActionButton>

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
+import analytics from '../../lib/analytics';
 
 const customContentStyle = {
   maxWidth: 600,
@@ -39,9 +40,11 @@ export default class JobEntry extends Component {
 		this.setState({ open: true });
 	};
 
-	handleClose = (e) => {
-    e.preventDefault();
-		this.props.handleDialog();
+	handleClose = (e, reason = 'unknown') => {
+    if (e && e.preventDefault) {
+      e.preventDefault();
+    }
+		this.props.handleDialog(reason);
 	}
 
   handleBoardName = (e) => { this.setState({ boardName: e.target.value }) };
@@ -53,9 +56,27 @@ export default class JobEntry extends Component {
   handleLocationChange = (e) => { this.setState({ location: e.target.value }) };
   handleJobUrlChange = (e) => { this.setState({ jobUrl: e.target.value }) };
   
-  onNewJobPostingSave = (e) => {
-    e.preventDefault();
-    util.submitNewJobPosting(this.state);
+  onNewJobPostingSave = () => {
+    const { boardName, companyName, jobTitle } = this.state;
+    const eventContext = {
+      boardName,
+      companyName,
+      jobTitle,
+    };
+
+    analytics.trackEvent('job_posting_submit_attempted', eventContext);
+
+    return util.submitNewJobPosting(this.state)
+      .then(() => {
+        analytics.trackEvent('job_posting_submit_succeeded', eventContext);
+      })
+      .catch((error) => {
+        const errorMessage = error && error.message ? error.message : 'unknown_error';
+        analytics.trackEvent('job_posting_submit_failed', {
+          ...eventContext,
+          errorMessage,
+        });
+      });
   }
 
   render() {
@@ -66,14 +87,14 @@ export default class JobEntry extends Component {
         label="Save"
         primary={true}
         onTouchTap={(e) => {
-         this.handleClose(e);
-         this.onNewJobPostingSave(e);
+         this.handleClose(e, 'save');
+         this.onNewJobPostingSave();
         }}
       />,
       <FlatButton
         label="Cancel"
         primary={true}
-        onTouchTap={handleDialog}
+        onTouchTap={() => handleDialog('cancel')}
       />,
     ];
     return (
@@ -149,5 +170,15 @@ export default class JobEntry extends Component {
         </Dialog>
       </div>
     )
-  }  
+  }
 }
+
+JobEntry.propTypes = {
+  handleDialog: PropTypes.func,
+  open: PropTypes.bool,
+};
+
+JobEntry.defaultProps = {
+  handleDialog: () => {},
+  open: false,
+};

--- a/database/db_helpers.js
+++ b/database/db_helpers.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const User = require('./models/users.js');
 const JobPost = require('./models/jobPost');
+const AnalyticsEvent = require('./models/analyticsEvent');
 Promise.promisifyAll(mongoose);
 
 module.exports.storeJobPosting = (postDetails) => {
@@ -20,4 +21,28 @@ module.exports.getJobPosting = (userInfo) => {
   .catch(err => {
     console.log('DBH: err storing job posting', err);
   })
+}
+
+module.exports.storeAnalyticsEvent = (eventPayload = {}) => {
+  if (!eventPayload.name) {
+    return Promise.reject(new Error('Analytics event name is required'));
+  }
+
+  const analyticsEvent = {
+    name: eventPayload.name,
+    data: eventPayload.data || {},
+  };
+
+  if (eventPayload.timestamp) {
+    const timestamp = new Date(eventPayload.timestamp);
+    if (!isNaN(timestamp.getTime())) {
+      analyticsEvent.createdAt = timestamp;
+    }
+  }
+
+  return AnalyticsEvent(analyticsEvent).saveAsync()
+    .catch(err => {
+      console.log('DBH: err storing analytics event', err);
+      throw err;
+    });
 }

--- a/database/models/analyticsEvent.js
+++ b/database/models/analyticsEvent.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const AnalyticsEventSchema = new Schema({
+  name: { type: String, required: true },
+  data: { type: Schema.Types.Mixed, default: {} },
+  createdAt: { type: Date, default: Date.now },
+}, {
+  minimize: false,
+});
+
+module.exports = mongoose.model('AnalyticsEvent', AnalyticsEventSchema);

--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -7,7 +7,7 @@ module.exports.storeJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }
@@ -18,7 +18,18 @@ module.exports.getJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
+}
+
+module.exports.storeAnalyticsEvent = (req, res) => {
+  return dbh.storeAnalyticsEvent(req.body)
+  .then(() => {
+    res.sendStatus(201);
+  })
+  .catch(err => {
+    console.log('RH: error in storeAnalyticsEvent', err);
+    res.status(400).send({ error: 'Unable to record analytics event' });
+  });
 }

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 app.post('/JobPosting', rh.storeJobPosting);
 app.get('/JobPosting', rh.getJobPosting)
+app.post('/analytics/events', rh.storeAnalyticsEvent);
 
 app.post('/entry', upload.single('media'), (req, res) => {
   if (req.body.text.length === 0) {


### PR DESCRIPTION
Summary:

Added end-to-end analytics instrumentation around the job posting flow so modal usage and submission outcomes are now recorded without impacting the UX.

- `client/lib/analytics.js:1` introduces a lightweight axios helper that posts named events to the new analytics endpoint.
- `client/src/components/App.js:42` tags every modal open/close with the trigger source so we can see how people reach or dismiss the form.
- `client/src/components/JobEntry.js:59` tracks submit attempts plus success/failure (with lightweight context) and forwards explicit close reasons; defaults guard the routed variant. 
- `database/models/analyticsEvent.js:1` and `database/db_helpers.js:26` define and persist analytics events, accepting optional timestamps while validating required fields.
- `server/requestHandlers.js:26` and `server/server.js:48` expose `/analytics/events`, returning 201 on success and surfacing write failures for monitoring.

Tests not run (project has no automated suite configured). If you want to verify end-to-end, consider starting the app and confirming events hit the new collection.