### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -55,7 +55,29 @@ export default class JobEntry extends Component {
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
+    const {
+      boardName,
+      companyName,
+      jobTitle,
+      location,
+      jobUrl,
+    } = this.state;
+
     util.submitNewJobPosting(this.state);
+
+    if (
+      typeof window !== 'undefined' &&
+      window.analytics &&
+      typeof window.analytics.track === 'function'
+    ) {
+      window.analytics.track('job_application_submitted', {
+        boardName,
+        companyName,
+        jobTitle,
+        location,
+        jobUrl,
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
Summary:

**Tracking Added**
- Added a guarded `window.analytics.track` call after `util.submitNewJobPosting` so submitting a job now emits a `job_application_submitted` event with board/company/title/location/url context (`client/src/components/JobEntry.js:56`).

- Tests: not run (no automated suite set up here). 

Next steps: 1) Manually verify in a staging build that the analytics event appears with the expected payload.