### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -55,7 +55,36 @@ export default class JobEntry extends Component {
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
-    util.submitNewJobPosting(this.state);
+    const jobDetails = { ...this.state };
+    const trackSubmission = () => {
+      if (
+        typeof window !== 'undefined' &&
+        window.analytics &&
+        typeof window.analytics.track === 'function'
+      ) {
+        const {
+          boardName,
+          companyName,
+          jobTitle,
+          location,
+          jobUrl,
+        } = jobDetails;
+        window.analytics.track('Job Application Submitted', {
+          boardName,
+          companyName,
+          jobTitle,
+          location,
+          jobUrl,
+        });
+      }
+    };
+
+    const submission = util.submitNewJobPosting(jobDetails);
+    if (submission && typeof submission.then === 'function') {
+      submission.then(trackSubmission).catch(() => {});
+    } else {
+      trackSubmission();
+    }
   }
 
   render() {


### PR DESCRIPTION
Summary:

**Analytics Added**
- Added guarded `window.analytics.track('Job Application Submitted', …)` call after saving the new job details so the event fires once the submission promise resolves, covering both promise and non-promise returns (`client/src/components/JobEntry.js:58`).

Tests not run; consider running the relevant frontend flow to confirm the dialog still submits & tracks as expected.