### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -55,6 +55,14 @@ export default class JobEntry extends Component {
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
+    if (typeof window !== 'undefined' && window.analytics && typeof window.analytics.track === 'function') {
+      window.analytics.track('job_application_submitted', {
+        boardName: this.state.boardName,
+        companyName: this.state.companyName,
+        jobTitle: this.state.jobTitle,
+        location: this.state.location,
+      });
+    }
     util.submitNewJobPosting(this.state);
   }
 


### PR DESCRIPTION
Summary:

Added an analytics hook when saving a new job entry. In `client/src/components/JobEntry.js:54-66`, the save handler now checks for `window.analytics` and calls `track('job_application_submitted', …)` with key form details before posting the job to the backend. No automated tests were run; you may want to trigger the UI flow and confirm the event appears in your analytics dashboard.