### PR TITLE
Changes from Codex

### DIFF
--- a/client/lib/analytics.js
+++ b/client/lib/analytics.js
@@ -1,0 +1,26 @@
+const isAnalyticsAvailable = () => (
+  typeof window !== 'undefined' &&
+  window.analytics &&
+  typeof window.analytics.track === 'function'
+);
+
+const trackJobApplicationSubmitted = (jobDetails = {}) => {
+  if (!isAnalyticsAvailable()) {
+    return;
+  }
+
+  const payload = {
+    boardName: jobDetails.boardName,
+    companyName: jobDetails.companyName,
+    jobTitle: jobDetails.jobTitle,
+    hasDescription: Boolean(jobDetails.jobDescription),
+    hasBasicQualifications: Boolean(jobDetails.basicQualifications),
+    hasPreferredQualifications: Boolean(jobDetails.preferredQualifications),
+    hasLocation: Boolean(jobDetails.location),
+    hasJobUrl: Boolean(jobDetails.jobUrl),
+  };
+
+  window.analytics.track('job_application_submitted', payload);
+};
+
+export default { trackJobApplicationSubmitted };

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
+import analytics from '../../lib/analytics';
 
 const customContentStyle = {
   maxWidth: 600,
@@ -56,6 +57,27 @@ export default class JobEntry extends Component {
   onNewJobPostingSave = (e) => {
     e.preventDefault();
     util.submitNewJobPosting(this.state);
+    const {
+      boardName,
+      companyName,
+      jobTitle,
+      jobDescription,
+      basicQualifications,
+      preferredQualifications,
+      location,
+      jobUrl,
+    } = this.state;
+
+    analytics.trackJobApplicationSubmitted({
+      boardName,
+      companyName,
+      jobTitle,
+      jobDescription,
+      basicQualifications,
+      preferredQualifications,
+      location,
+      jobUrl,
+    });
   }
 
   render() {


### PR DESCRIPTION
Summary:

Hooked the job submission flow into analytics so the `job_application_submitted` event fires whenever a user saves a new application.

- `client/lib/analytics.js:1` – added a small helper that guards against missing trackers and emits the event with a trimmed payload of job details.
- `client/src/components/JobEntry.js:3` & `client/src/components/JobEntry.js:65` – import the helper and trigger the tracking call right after the existing submission request.

Tests not run (no test suite observed). Next step you might want: 1) Manually verify the event appears in your analytics dashboard once this ships.