### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -52,10 +52,29 @@ export default class JobEntry extends Component {
   handlePreferredQualificationsChange = (e) => { this.setState({ preferredQualifications: e.target.value }) };
   handleLocationChange = (e) => { this.setState({ location: e.target.value }) };
   handleJobUrlChange = (e) => { this.setState({ jobUrl: e.target.value }) };
+
+  trackJobSubmission = (jobDetails) => {
+    if (typeof window === 'undefined') { return; }
+
+    const { analytics } = window;
+
+    if (analytics && typeof analytics.track === 'function') {
+      analytics.track('Job Application Submitted', {
+        boardName: jobDetails.boardName,
+        companyName: jobDetails.companyName,
+        jobTitle: jobDetails.jobTitle,
+        location: jobDetails.location,
+        jobUrl: jobDetails.jobUrl,
+      });
+    }
+  };
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
-    util.submitNewJobPosting(this.state);
+    const jobDetails = { ...this.state };
+
+    util.submitNewJobPosting(jobDetails);
+    this.trackJobSubmission(jobDetails);
   }
 
   render() {


### PR DESCRIPTION
Summary:

Hooked the job submission flow to emit an analytics event when the form is saved.
- `client/src/components/JobEntry.js:55` added `trackJobSubmission` to safely call `window.analytics.track('Job Application Submitted', …)` with the key job metadata when analytics is available.
- `client/src/components/JobEntry.js:69` now clones the current form state before posting and triggers the new tracker immediately after submitting the job.
- Tests not run (not requested).

Next steps:
1. Submit a test job entry in the app and confirm the `Job Application Submitted` event appears in your analytics dashboard.