### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -55,7 +55,23 @@ export default class JobEntry extends Component {
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
-    util.submitNewJobPosting(this.state);
+    const { boardName, companyName, jobTitle, jobUrl } = this.state;
+
+    return util.submitNewJobPosting(this.state)
+      .then((response) => {
+        const analytics = typeof window !== 'undefined' ? window.analytics : null;
+
+        if (analytics && typeof analytics.track === 'function') {
+          analytics.track('Job Application Submitted', {
+            boardName,
+            companyName,
+            jobTitle,
+            jobUrl,
+          });
+        }
+
+        return response;
+      });
   }
 
   render() {


### PR DESCRIPTION
Summary:

Added analytics instrumentation to the job submission handler so successful saves now call `analytics.track` with key job details when the tracker is available (`client/src/components/JobEntry.js:63`). Guard keeps existing behavior if analytics isn’t configured.

- `analytics.track('Job Application Submitted', …)` fires only after the POST promise resolves.
- Payload includes board, company, job title, and URL while returning the original promise for any upstream consumers.

I didn’t run project tests; consider a quick manual submit in the UI to confirm the event appears in your analytics dashboard.