### PR TITLE
Changes from Codex

### DIFF
--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -7,7 +7,7 @@ module.exports.storeJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }
@@ -18,7 +18,7 @@ module.exports.getJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }


### PR DESCRIPTION
Summary:

- Replaced the typoed `consol.elog` with `console.log` in both request error handlers so failures log correctly (`server/requestHandlers.js:10`, `server/requestHandlers.js:21`).

Next steps: 1) Hit either handler and confirm the error message now prints to the console.