### PR TITLE
Changes from Codex

### DIFF
--- a/client/lib/analytics.js
+++ b/client/lib/analytics.js
@@ -1,0 +1,67 @@
+const EVENT_NAMES = {
+  JOB_VIEWED: 'Job Posting Viewed',
+  JOB_APPLICATION: 'Job Application',
+};
+
+const isFunction = fn => typeof fn === 'function';
+const isWindowAvailable = () => typeof window !== 'undefined';
+
+const sanitizePayload = (payload = {}) => {
+  return Object.keys(payload).reduce((acc, key) => {
+    const value = payload[key];
+    if (value !== undefined && value !== null && value !== '') {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
+const extractJobDetails = job => {
+  if (!job || typeof job !== 'object') {
+    return {};
+  }
+
+  const jobId = job._id || job.id || job.jobId || null;
+
+  return sanitizePayload({
+    jobId,
+    boardName: job.boardName,
+    companyName: job.companyName,
+    jobTitle: job.jobTitle,
+    location: job.location,
+    jobUrl: job.jobUrl,
+  });
+};
+
+const trackEvent = (name, payload = {}) => {
+  const data = sanitizePayload(payload);
+
+  if (isWindowAvailable() && window.analytics && isFunction(window.analytics.track)) {
+    window.analytics.track(name, data);
+    return;
+  }
+
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.info(`[analytics] ${name}`, data);
+  }
+};
+
+const trackJobViewed = (job, context = {}) => {
+  trackEvent(EVENT_NAMES.JOB_VIEWED, {
+    ...extractJobDetails(job),
+    ...context,
+  });
+};
+
+const trackJobApplication = (job, context = {}) => {
+  trackEvent(EVENT_NAMES.JOB_APPLICATION, {
+    ...extractJobDetails(job),
+    ...context,
+  });
+};
+
+export default {
+  trackJobViewed,
+  trackJobApplication,
+};

--- a/client/src/components/JobBoard/Card.js
+++ b/client/src/components/JobBoard/Card.js
@@ -4,6 +4,7 @@ import { DragSource, DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 import flow from 'lodash/flow';
 import JobCard from '../JobCard';
+import analytics from '../../../lib/analytics';
 
 class Card extends Component {
   constructor(props) {
@@ -14,9 +15,19 @@ class Card extends Component {
   }
 
   handleDialog() {
-    console.log('handle toggleed');
-    this.setState({
-      open: !this.state.open 
+    const { card, listHeader } = this.props;
+
+    this.setState(prevState => {
+      const nextOpen = !prevState.open;
+
+      if (!prevState.open) {
+        analytics.trackJobViewed(card, {
+          source: 'job-card',
+          boardName: listHeader,
+        });
+      }
+
+      return { open: nextOpen };
     });
   }
 
@@ -42,6 +53,7 @@ const cardSource = {
     return {
       index: props.index,
       listId: props.listId,
+      listHeader: props.listHeader,
       card: props.card
     };
   },

--- a/client/src/components/JobBoard/ListCardContainer.js
+++ b/client/src/components/JobBoard/ListCardContainer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import update from 'react/lib/update';
 import Card from './Card';
 import { DropTarget } from 'react-dnd';
+import analytics from '../../../lib/analytics';
 
 class ListCardContainer extends Component {
 
@@ -58,6 +59,7 @@ class ListCardContainer extends Component {
               key={card.id}
               index={i}
               listId={this.props.id}
+              listHeader={header}
               card={card}                           
               removeCard={this.removeCard.bind(this)}
               moveCard={this.moveCard.bind(this)} />
@@ -69,15 +71,35 @@ class ListCardContainer extends Component {
 }
 
 const cardTarget = {
-  drop(props, monitor, component ) {
-    const { id } = props;
-    const sourceObj = monitor.getItem();    
-    if ( id !== sourceObj.listId ) component.pushCard(sourceObj.card);
+  drop(props, monitor, component) {
+    const { id, header } = props;
+    const sourceObj = monitor.getItem();
+    const movedToDifferentList = id !== sourceObj.listId;
+
+    if (movedToDifferentList) {
+      component.pushCard(sourceObj.card);
+
+      if (header && header.toLowerCase() === 'applied') {
+        analytics.trackJobApplication(sourceObj.card, {
+          sourceBoard: sourceObj.listHeader,
+          targetBoard: header,
+          interaction: 'drag-and-drop',
+        });
+      }
+
+      monitor.getItem().listId = id;
+      monitor.getItem().listHeader = header;
+
+      if (sourceObj.card) {
+        sourceObj.card.boardName = header;
+      }
+    }
+
     return {
-      listId: id
+      listId: id,
     };
   }
-}
+};
 
 export default DropTarget("CARD", cardTarget, (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
+import analytics from '../../lib/analytics';
 
 const customContentStyle = {
   maxWidth: 600,
@@ -56,6 +57,12 @@ export default class JobEntry extends Component {
   onNewJobPostingSave = (e) => {
     e.preventDefault();
     util.submitNewJobPosting(this.state);
+
+    if (this.state.boardName && this.state.boardName.trim().toLowerCase() === 'applied') {
+      analytics.trackJobApplication(this.state, {
+        source: 'job-entry-dialog',
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
Summary:

**Analytics Events**  
- Added `client/lib/analytics.js:1` with safe helpers for tracking job views and applications via `window.analytics` (falls back to console in dev).  
- Instrumented modal opens in `client/src/components/JobBoard/Card.js:18` so each job detail view fires a `Job Posting Viewed` analytics event enriched with the board context.  
- Hooked drag/drop moves in `client/src/components/JobBoard/ListCardContainer.js:73` to emit `Job Application` events when a card enters the Applied column, while updating the card’s `boardName` metadata.  
- Tracked manual saves directly into the Applied board in `client/src/components/JobEntry.js:57`, covering applications created through the dialog.

**Testing**  
- Not run (no automated suite provided).

**Next Steps**  
- 1) Verify that the production build loads the intended analytics provider so these events reach your analytics backend.