### PR TITLE
Changes from Codex

### DIFF
--- a/client/lib/analytics.js
+++ b/client/lib/analytics.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+const ANALYTICS_ENDPOINT = '/analytics/track';
+
+export const trackJobBoardEvent = (eventName, properties = {}) => {
+  if (!eventName) {
+    return Promise.resolve();
+  }
+
+  const payload = {
+    eventName,
+    properties,
+    timestamp: new Date().toISOString()
+  };
+
+  return axios.post(ANALYTICS_ENDPOINT, payload)
+    .catch((error) => {
+      // Swallow analytics errors so they never block the UI.
+      console.error('Analytics track failed', error);
+    });
+};
+
+export default {
+  trackJobBoardEvent
+};

--- a/client/src/components/JobBoard/Board.js
+++ b/client/src/components/JobBoard/Board.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ListCardContainer from './ListCardContainer';
 import util from '../../../lib/util';
+import { trackJobBoardEvent } from '../../../lib/analytics';
 
 export default class Board extends React.Component {
   static propTypes = {
@@ -58,7 +59,16 @@ export default class Board extends React.Component {
   componentWillMount() {
     return util.fetchJobPosting()
     .then( result => { 
-      this.setState({ list: result }) 
+      this.setState({ list: result });
+      trackJobBoardEvent('job_board_loaded', {
+        listCount: Array.isArray(result) ? result.length : 0
+      });
+    });
+  }
+
+  componentDidMount() {
+    trackJobBoardEvent('job_board_viewed', {
+      initialListCount: Array.isArray(this.state.list) ? this.state.list.length : 0
     });
   }
 

--- a/client/src/components/JobBoard/Card.js
+++ b/client/src/components/JobBoard/Card.js
@@ -4,6 +4,7 @@ import { DragSource, DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 import flow from 'lodash/flow';
 import JobCard from '../JobCard';
+import { trackJobBoardEvent } from '../../../lib/analytics';
 
 class Card extends Component {
   constructor(props) {
@@ -14,10 +15,22 @@ class Card extends Component {
   }
 
   handleDialog() {
-    console.log('handle toggleed');
+    const willOpen = !this.state.open;
+
     this.setState({
-      open: !this.state.open 
+      open: willOpen 
     });
+
+    const { card, listHeader } = this.props;
+
+    const payload = {
+      listHeader,
+      companyName: card.companyName,
+      jobTitle: card.jobTitle,
+      cardId: card.id || card._id
+    };
+
+    trackJobBoardEvent(willOpen ? 'job_board_card_opened' : 'job_board_card_closed', payload);
   }
 
   render() {
@@ -41,8 +54,10 @@ const cardSource = {
   beginDrag(props) {
     return {
       index: props.index,
+      initialIndex: props.index,
       listId: props.listId,
-      card: props.card
+      card: props.card,
+      listHeader: props.listHeader
     };
   },
 
@@ -116,3 +131,18 @@ export default flow(
     isDragging: monitor.isDragging()
   }))
 )(Card);
+
+Card.propTypes = {
+  card: PropTypes.object.isRequired,
+  listHeader: PropTypes.string,
+  index: PropTypes.number.isRequired,
+  listId: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]).isRequired,
+  removeCard: PropTypes.func.isRequired,
+  moveCard: PropTypes.func.isRequired,
+  connectDragSource: PropTypes.func.isRequired,
+  connectDropTarget: PropTypes.func.isRequired,
+  isDragging: PropTypes.bool
+};

--- a/client/src/components/JobBoard/ListCardContainer.js
+++ b/client/src/components/JobBoard/ListCardContainer.js
@@ -2,12 +2,36 @@ import React, { Component } from 'react';
 import update from 'react/lib/update';
 import Card from './Card';
 import { DropTarget } from 'react-dnd';
+import { trackJobBoardEvent } from '../../../lib/analytics';
 
 class ListCardContainer extends Component {
 
   constructor(props) {
     super(props);   
     this.state = { cards: props.list };
+  }
+
+  logCardMove(card, sourceListId, destinationListId, sourceHeader, destinationHeader) {
+    trackJobBoardEvent('job_board_card_moved', {
+      cardId: card.id || card._id,
+      companyName: card.companyName,
+      jobTitle: card.jobTitle,
+      fromListId: sourceListId,
+      toListId: destinationListId,
+      fromListHeader: sourceHeader,
+      toListHeader: destinationHeader
+    });
+  }
+
+  logCardReorder(card, fromIndex, toIndex, listHeader) {
+    trackJobBoardEvent('job_board_card_reordered', {
+      cardId: card.id || card._id,
+      companyName: card.companyName,
+      jobTitle: card.jobTitle,
+      fromIndex,
+      toIndex,
+      listHeader
+    });
   }
 
   pushCard(card) {
@@ -58,6 +82,7 @@ class ListCardContainer extends Component {
               key={card.id}
               index={i}
               listId={this.props.id}
+              listHeader={header}
               card={card}                           
               removeCard={this.removeCard.bind(this)}
               moveCard={this.moveCard.bind(this)} />
@@ -72,7 +97,17 @@ const cardTarget = {
   drop(props, monitor, component ) {
     const { id } = props;
     const sourceObj = monitor.getItem();    
-    if ( id !== sourceObj.listId ) component.pushCard(sourceObj.card);
+    const targetHeader = props.header;
+
+    if ( id !== sourceObj.listId ) {
+      const updatedCard = Object.assign({}, sourceObj.card, { boardName: targetHeader });
+      component.pushCard(updatedCard);
+      component.logCardMove(updatedCard, sourceObj.listId, id, sourceObj.listHeader, targetHeader);
+      monitor.getItem().card = updatedCard;
+    } else if (sourceObj.initialIndex !== monitor.getItem().index) {
+      component.logCardReorder(sourceObj.card, sourceObj.initialIndex, monitor.getItem().index, targetHeader);
+    }
+
     return {
       listId: id
     };

--- a/database/db_helpers.js
+++ b/database/db_helpers.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const User = require('./models/users.js');
 const JobPost = require('./models/jobPost');
+const AnalyticsEvent = require('./models/analyticsEvent');
 Promise.promisifyAll(mongoose);
 
 module.exports.storeJobPosting = (postDetails) => {
@@ -20,4 +21,18 @@ module.exports.getJobPosting = (userInfo) => {
   .catch(err => {
     console.log('DBH: err storing job posting', err);
   })
+}
+
+module.exports.storeAnalyticsEvent = (eventDetails = {}) => {
+  const payload = Object.assign({}, eventDetails);
+
+  if (payload.timestamp) {
+    payload.timestamp = new Date(payload.timestamp);
+  }
+
+  return AnalyticsEvent(payload).saveAsync()
+  .catch(err => {
+    console.log('DBH: err storing analytics event', err);
+    throw err;
+  });
 }

--- a/database/models/analyticsEvent.js
+++ b/database/models/analyticsEvent.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const AnalyticsEventSchema = new Schema({
+  eventName: { type: String, required: true },
+  properties: { type: Schema.Types.Mixed, default: {} },
+  timestamp: { type: Date, default: Date.now }
+});
+
+const AnalyticsEvent = mongoose.model('AnalyticsEvent', AnalyticsEventSchema);
+
+module.exports = AnalyticsEvent;

--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -22,3 +22,18 @@ module.exports.getJobPosting = (req, res) => {
     res.status(500);
   })
 }
+
+module.exports.trackAnalyticsEvent = (req, res) => {
+  if (!req.body || !req.body.eventName) {
+    return res.status(400).send({ error: 'eventName is required' });
+  }
+
+  return dbh.storeAnalyticsEvent(req.body)
+  .then(() => {
+    res.sendStatus(204);
+  })
+  .catch(err => {
+    consol.elog('RH: error in trackAnalyticsEvent', err);
+    res.status(500).send({ error: 'Failed to store analytics event' });
+  });
+}

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 app.post('/JobPosting', rh.storeJobPosting);
 app.get('/JobPosting', rh.getJobPosting)
+app.post('/analytics/track', rh.trackAnalyticsEvent);
 
 app.post('/entry', upload.single('media'), (req, res) => {
   if (req.body.text.length === 0) {


### PR DESCRIPTION
Summary:

**Analytics Tracking**
- Added a reusable client helper for posting analytics events and hooked board load/view instrumentation to it (`client/lib/analytics.js:1`, `client/src/components/JobBoard/Board.js:59`).
- Logged meaningful context whenever a job card dialog opens/closes or is dragged, including column metadata and stable IDs (`client/src/components/JobBoard/Card.js:17`, `client/src/components/JobBoard/ListCardContainer.js:14`).
- Persisted job board interaction events through a new analytics model, DB helper, request handler, and Express route (`database/models/analyticsEvent.js:1`, `database/db_helpers.js:26`, `server/requestHandlers.js:26`, `server/server.js:46`).

Tests: not run (no automated suite configured).

Next steps: 1) Start the server with Mongo running and exercise the board to confirm events appear in the `analyticsEvents` collection. 2) Optionally add reporting/aggregation to surface the captured insights.