### PR TITLE
Changes from Codex

### DIFF
--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -7,7 +7,7 @@ module.exports.storeJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }
@@ -18,7 +18,7 @@ module.exports.getJobPosting = (req, res) => {
     res.status(200).send(success);
   })
   .catch(err => {
-    consol.elog('RH: error in storeJobPosting', err);
+    console.log('RH: error in storeJobPosting', err);
     res.status(500);
   })
 }


### PR DESCRIPTION
Summary:

Replaced the typo `consol.elog` with `console.log` in both error handlers so failures now log correctly (`server/requestHandlers.js:10`, `server/requestHandlers.js:21`). You can run the existing server-side tests or start the server to confirm logging if needed.