### PR TITLE
Changes from Codex

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,12 @@ const multerS3 = require('multer-s3');
 const s3 = new AWS.S3();
 const database = require('../database/dbHelper');
 
+const SPARKPOST_API_KEY = process.env.SPARKPOST_API_KEY;
+
+if (!SPARKPOST_API_KEY) {
+  throw new Error('Missing SparkPost API key. Set SPARKPOST_API_KEY environment variable.');
+}
+
 const upload = multer({
   storage: multerS3({
     s3: s3,
@@ -127,7 +133,7 @@ app.post('/setReminder', function (req, res) {
     url: 'https://api.sparkpost.com/api/v1/transmissions',
     headers: {
       'content-type': 'application/json',
-      'authorization': '0526b81c29cb593ff22fd28413a1e139eedbb0ac'
+      'authorization': SPARKPOST_API_KEY
     },
     data: {
       "options":{"open_tracking":true,"click_tracking":true,"start_time": thankYouTime},


### PR DESCRIPTION
Summary:

**Change Summary**
- Pull SparkPost API key from `process.env.SPARKPOST_API_KEY` and fail fast if it’s missing so the server won’t start with a misconfiguration (`server/server.js:12-16`).
- Update the SparkPost request headers to use the environment-sourced key instead of the previously hardcoded value (`server/server.js:104`).

**Status**
- Tests not run (not requested).

**Next Steps**
1. Export `SPARKPOST_API_KEY` in your local/production environment before starting the server.
2. Hit `/setReminder` once the key is configured to confirm SparkPost accepts the request.