### PR TITLE
Changes from Codex

### DIFF
--- a/client/lib/analytics.js
+++ b/client/lib/analytics.js
@@ -1,0 +1,58 @@
+const getAnalyticsTarget = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window;
+};
+
+const trackWithProvider = (provider, eventName, properties) => {
+  try {
+    return provider(eventName, properties);
+  } catch (err) {
+    /* eslint-disable no-console */
+    console.warn('Analytics provider failed', err);
+    /* eslint-enable no-console */
+  }
+  return null;
+};
+
+const trackEvent = (eventName, properties = {}) => {
+  if (!eventName) {
+    return;
+  }
+
+  const payload = properties || {};
+  const target = getAnalyticsTarget();
+
+  if (!target) {
+    return;
+  }
+
+  const { analytics, gtag, dataLayer, mixpanel } = target;
+
+  if (analytics && typeof analytics.track === 'function') {
+    trackWithProvider(analytics.track.bind(analytics), eventName, payload);
+    return;
+  }
+
+  if (typeof gtag === 'function') {
+    trackWithProvider((name, props) => gtag('event', name, props), eventName, payload);
+    return;
+  }
+
+  if (dataLayer && typeof dataLayer.push === 'function') {
+    dataLayer.push(Object.assign({ event: eventName }, payload));
+    return;
+  }
+
+  if (mixpanel && typeof mixpanel.track === 'function') {
+    trackWithProvider(mixpanel.track.bind(mixpanel), eventName, payload);
+    return;
+  }
+
+  /* eslint-disable no-console */
+  console.info('Analytics event', eventName, payload);
+  /* eslint-enable no-console */
+};
+
+export default { trackEvent };

--- a/client/src/components/Call.js
+++ b/client/src/components/Call.js
@@ -5,6 +5,7 @@ import VoiceRecognition from './VoiceRecognition';
 import RecordRTC from 'recordrtc';
 import axios from 'axios';
 import EntryList from '../containers/entry-list/EntryList';
+import analytics from '../../lib/analytics';
 
 export default class Call extends React.Component {
   static propTypes = {
@@ -91,6 +92,10 @@ export default class Call extends React.Component {
       uploadSuccess: false,
       noTranscript: false
     });
+    analytics.trackEvent('call_recording_started', {
+      questionId: this.state.question,
+      autoStopMs: 30000
+    });
   }
 
   stopRecord() {
@@ -99,6 +104,10 @@ export default class Call extends React.Component {
         blob: this.state.recordAudio.blob,
         src: audioURL,
         stop: true
+      });
+      analytics.trackEvent('call_recording_stopped', {
+        questionId: this.state.question,
+        hasTranscript: Boolean(this.state.transcript)
       });
     });
   }
@@ -114,9 +123,17 @@ export default class Call extends React.Component {
     axios.post('/entry', fd, config)
     .then( res => {
       console.log('Successful upload!');
+      analytics.trackEvent('call_recording_uploaded', {
+        questionId: this.state.question,
+        transcriptLength: this.state.transcript.length
+      });
     })
     .catch(err => {
       console.log('Error uploading...');
+      analytics.trackEvent('call_recording_upload_failed', {
+        questionId: this.state.question,
+        error: err && err.message
+      });
     });
   }
 

--- a/client/src/components/InterviewTab.js
+++ b/client/src/components/InterviewTab.js
@@ -4,6 +4,7 @@ import DatePicker from 'material-ui/DatePicker';
 import TimePicker from 'material-ui/TimePicker';
 import RaisedButton from 'material-ui/RaisedButton';
 import axios from 'axios';
+import analytics from '../../lib/analytics';
 
 export default class InterviewTab extends Component {
   constructor(props) {
@@ -46,12 +47,19 @@ export default class InterviewTab extends Component {
       reminderTime: interviewTime,
       followUpDate: followUpDate
     })
-    .then(function (response) {
+    .then((response) => {
       // TODO: Show snackbar as confirmation of reminder
       console.log(response);
+      analytics.trackEvent('interview_reminder_scheduled', {
+        reminderDate: interviewDate && interviewDate.toISOString(),
+        reminderTime: interviewTime && interviewTime.toString()
+      });
     })
-    .catch(function (error) {
+    .catch((error) => {
       console.log(error);
+      analytics.trackEvent('interview_reminder_failed', {
+        error: error && error.message
+      });
     });
   }
 

--- a/client/src/components/JobBoard/Board.js
+++ b/client/src/components/JobBoard/Board.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ListCardContainer from './ListCardContainer';
 import util from '../../../lib/util';
+import analytics from '../../../lib/analytics';
 
 export default class Board extends React.Component {
   static propTypes = {
@@ -58,7 +59,13 @@ export default class Board extends React.Component {
   componentWillMount() {
     return util.fetchJobPosting()
     .then( result => { 
-      this.setState({ list: result }) 
+      const lists = Array.isArray(result) ? result : [];
+      this.setState({ list: lists }) 
+      const totalJobs = lists.reduce((count, column) => count + (column.cards ? column.cards.length : 0), 0);
+      analytics.trackEvent('job_board_loaded', {
+        boardCount: lists.length,
+        jobCount: totalJobs
+      });
     });
   }
 

--- a/client/src/components/JobBoard/Card.js
+++ b/client/src/components/JobBoard/Card.js
@@ -42,7 +42,8 @@ const cardSource = {
     return {
       index: props.index,
       listId: props.listId,
-      card: props.card
+      card: props.card,
+      listHeader: props.listHeader
     };
   },
 

--- a/client/src/components/JobBoard/ListCardContainer.js
+++ b/client/src/components/JobBoard/ListCardContainer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import update from 'react/lib/update';
 import Card from './Card';
 import { DropTarget } from 'react-dnd';
+import analytics from '../../../lib/analytics';
 
 class ListCardContainer extends Component {
 
@@ -39,7 +40,14 @@ class ListCardContainer extends Component {
           [hoverIndex, 0, dragCard]
         ]
       }
-    }));
+    }), () => {
+      analytics.trackEvent('job_board_card_reordered', {
+        list: this.props.header,
+        cardId: dragCard.id,
+        fromIndex: dragIndex,
+        toIndex: hoverIndex
+      });
+    });
   }
 
   render() {
@@ -58,6 +66,7 @@ class ListCardContainer extends Component {
               key={card.id}
               index={i}
               listId={this.props.id}
+              listHeader={header}
               card={card}                           
               removeCard={this.removeCard.bind(this)}
               moveCard={this.moveCard.bind(this)} />
@@ -72,7 +81,16 @@ const cardTarget = {
   drop(props, monitor, component ) {
     const { id } = props;
     const sourceObj = monitor.getItem();    
-    if ( id !== sourceObj.listId ) component.pushCard(sourceObj.card);
+    if ( id !== sourceObj.listId ) {
+      analytics.trackEvent('job_board_card_moved', {
+        cardId: sourceObj.card && sourceObj.card.id,
+        fromListId: sourceObj.listId,
+        fromList: sourceObj.listHeader,
+        toListId: id,
+        toList: props.header
+      });
+      component.pushCard(sourceObj.card);
+    }
     return {
       listId: id
     };

--- a/client/src/components/JobEntry.js
+++ b/client/src/components/JobEntry.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { FlatButton, RaisedButton, Dialog, TextField } from 'material-ui';
 import util from '../../lib/util';
+import analytics from '../../lib/analytics';
 
 const customContentStyle = {
   maxWidth: 600,
@@ -55,7 +56,23 @@ export default class JobEntry extends Component {
   
   onNewJobPostingSave = (e) => {
     e.preventDefault();
-    util.submitNewJobPosting(this.state);
+    return util.submitNewJobPosting(this.state)
+      .then(() => {
+        analytics.trackEvent('job_saved', {
+          boardName: this.state.boardName,
+          companyName: this.state.companyName,
+          jobTitle: this.state.jobTitle
+        });
+      })
+      .catch((err) => {
+        analytics.trackEvent('job_save_failed', {
+          boardName: this.state.boardName,
+          companyName: this.state.companyName,
+          jobTitle: this.state.jobTitle,
+          error: err && err.message
+        });
+        throw err;
+      });
   }
 
   render() {


### PR DESCRIPTION
Summary:

**Summary**
- Added a shared analytics helper with graceful fallbacks so events consistently route through Segment/gtag/dataLayer/mixpanel or log when unavailable (`client/lib/analytics.js`).
- Emitted board lifecycle events—data load counts and per-card reorder/move details—by instrumenting the board, list container, and drag metadata (`client/src/components/JobBoard/Board.js:4`, `client/src/components/JobBoard/ListCardContainer.js:5`, `client/src/components/JobBoard/Card.js:1`).
- Tracked job saves, reminder submissions, and call recording/upload flows (success + failure) to capture the remaining user actions lacking telemetry (`client/src/components/JobEntry.js:4`, `client/src/components/InterviewTab.js:7`, `client/src/components/Call.js:8`).

**Testing**
- Not run (not requested).

Let me know if you’d like me to run the build or help wire these events to a specific analytics backend.