### PR TITLE
Changes from Codex

### DIFF
--- a/database/dbHelper.js
+++ b/database/dbHelper.js
@@ -1,9 +1,13 @@
 const mongoose = require('mongoose');
-mongoose.Promise = require('bluebird');
+const Promise = require('bluebird');
+mongoose.Promise = Promise;
 const mongoDatabase = require('./models/users');
 const User = mongoDatabase.User;
 
-exports.saveEntry = (req, res, log) => {
+exports.saveEntry = (log = {}) => {
+  if (!log.user_id) {
+    return Promise.reject(new Error('user_id is required to save entry'));
+  }
   let logEntry = {
     created_at: Date.now(),
     audio: {
@@ -12,14 +16,9 @@ exports.saveEntry = (req, res, log) => {
     },
     text: log.text,
   };
-  User.findOneAndUpdate({user_id: log.user_id}, {
+  return User.findOneAndUpdate({user_id: log.user_id}, {
     $push: {'entries': logEntry}
-  }, {safe: true, upsert: true, new: true})
-  .then(() => {
-    res.sendStatus(201);
-  })
-  .error(err => res.sendStatus(500).send(err))
-  .catch(err => res.sendStatus(400).send(err));
+  }, {safe: true, upsert: true, new: true});
 };
 
 exports.retrieveEntry = (query) => {

--- a/server/server.js
+++ b/server/server.js
@@ -47,19 +47,48 @@ app.post('/JobPosting', rh.storeJobPosting);
 app.get('/JobPosting', rh.getJobPosting)
 
 app.post('/entry', upload.single('media'), (req, res) => {
-  if (req.body.text.length === 0) {
-    res.sendStatus(400);
-  }
-  let log = {
-    user_id: req.body.user_id ? user_id : '123',
-    audio: {
-      bucket: req.file ? req.file.bucket : null,
-      key: req.file ? req.file.key : null,
-    },
-    text: req.body.text,
-  };
-  database.saveEntry(req, res, log);
+  const rawUserId = req.body && req.body.user_id;
+  const userId = typeof rawUserId === 'string'
+    ? rawUserId.trim()
+    : (rawUserId ? String(rawUserId).trim() : '');
 
+  if (!userId) {
+    return res.status(400).json({ error: 'user_id is required' });
+  }
+
+  const rawText = req.body && req.body.text;
+  const text = typeof rawText === 'string'
+    ? rawText.trim()
+    : (rawText ? String(rawText).trim() : '');
+
+  const hasText = text.length > 0;
+  const hasMedia = Boolean(req.file);
+
+  if (!hasText && !hasMedia) {
+    return res.status(400).json({ error: 'Entry must include text or media' });
+  }
+
+  if (hasMedia && (!req.file.bucket || !req.file.key)) {
+    return res.status(422).json({ error: 'Uploaded media metadata is incomplete' });
+  }
+
+  const log = {
+    user_id: userId,
+    audio: {
+      bucket: hasMedia ? req.file.bucket : null,
+      key: hasMedia ? req.file.key : null,
+    },
+    text: hasText ? text : null,
+  };
+
+  database.saveEntry(log)
+    .then(() => {
+      return res.status(201).json({ message: 'Entry saved' });
+    })
+    .catch(err => {
+      console.error('Failed to save entry', err);
+      return res.status(500).json({ error: 'Failed to save entry' });
+    });
 });
 
 app.post('/db/retrieveEntry', (req, res) => {


### PR DESCRIPTION
Summary:

**Summary**
- `server/server.js:49-92` now sanitizes `req.body.user_id` and `req.body.text`, requires at least text or media, validates uploaded media metadata, and responds with JSON errors/success while passing a clean log object to the DB layer instead of defaulting to user `123`.
- `database/dbHelper.js:1-22` now depends solely on the provided log payload, explicitly rejects missing `user_id` values, and returns the `findOneAndUpdate` promise so the route controls the HTTP response.

**Testing**
- Not run (not requested).

**Next Steps**
- Make sure any client posting to `/entry` includes a valid `user_id` to satisfy the new validation rules.