### PR TITLE
Changes from Codex

### DIFF
--- a/database/db_helpers.js
+++ b/database/db_helpers.js
@@ -13,9 +13,8 @@ module.exports.storeJobPosting = (postDetails) => {
   })
 }
 
-module.exports.getJobPosting = (userInfo) => {
-  //connect with userInfo Auth later
-  return JobPost.find()
+module.exports.getJobPosting = (userId) => {
+  return JobPost.find({ user_id: userId })
   .then( result => result)
   .catch(err => {
     console.log('DBH: err storing job posting', err);

--- a/database/models/jobPost.js
+++ b/database/models/jobPost.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const JobPostSchema = mongoose.Schema({
+    user_id: { type: String, required: true },
     boardName: { type: String, default: 'Interested' },
     companyName: { type: String, default: null },
     jobTitle: { type: String, default: null },

--- a/server/authMiddleware.js
+++ b/server/authMiddleware.js
@@ -1,0 +1,33 @@
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (serviceAccount) {
+    admin.initializeApp({
+      credential: admin.credential.cert(JSON.parse(serviceAccount))
+    });
+  } else {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault()
+    });
+  }
+}
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers.authorization || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+
+  if (!match) {
+    return res.status(401).send('Unauthorized');
+  }
+
+  return admin
+    .auth()
+    .verifyIdToken(match[1])
+    .then((decodedToken) => {
+      req.user = decodedToken;
+      req.userId = decodedToken.uid;
+      next();
+    })
+    .catch(() => res.status(401).send('Unauthorized'));
+};

--- a/server/requestHandlers.js
+++ b/server/requestHandlers.js
@@ -2,7 +2,10 @@ const user = require('../database/models/users.js');
 const dbh = require('../database/db_helpers');
 
 module.exports.storeJobPosting = (req, res) => {
-  return dbh.storeJobPosting(req.body.params.postDetails)
+  const postDetails = Object.assign({}, req.body.params.postDetails, {
+    user_id: req.userId
+  });
+  return dbh.storeJobPosting(postDetails)
   .then(success => {
     res.status(200).send(success);
   })
@@ -13,7 +16,7 @@ module.exports.storeJobPosting = (req, res) => {
 }
 
 module.exports.getJobPosting = (req, res) => {
-  return dbh.getJobPosting()
+  return dbh.getJobPosting(req.userId)
   .then(success => {
     res.status(200).send(success);
   })

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ const multer = require('multer');
 const multerS3 = require('multer-s3');
 const s3 = new AWS.S3();
 const database = require('../database/dbHelper');
+const authMiddleware = require('./authMiddleware');
 
 const upload = multer({
   storage: multerS3({
@@ -43,15 +44,15 @@ app.use(express.static(__dirname + '/../client/dist'))
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.post('/JobPosting', rh.storeJobPosting);
-app.get('/JobPosting', rh.getJobPosting)
+app.post('/JobPosting', authMiddleware, rh.storeJobPosting);
+app.get('/JobPosting', authMiddleware, rh.getJobPosting)
 
-app.post('/entry', upload.single('media'), (req, res) => {
+app.post('/entry', authMiddleware, upload.single('media'), (req, res) => {
   if (req.body.text.length === 0) {
     res.sendStatus(400);
   }
   let log = {
-    user_id: req.body.user_id ? user_id : '123',
+    user_id: req.userId,
     audio: {
       bucket: req.file ? req.file.bucket : null,
       key: req.file ? req.file.key : null,
@@ -62,9 +63,9 @@ app.post('/entry', upload.single('media'), (req, res) => {
 
 });
 
-app.post('/db/retrieveEntry', (req, res) => {
+app.post('/db/retrieveEntry', authMiddleware, (req, res) => {
   let query = {};
-  query.user_id = req.body.user_id ? req.body.user_id : '123';
+  query.user_id = req.userId;
   database.retrieveEntry(query)
   .then((results) => {
     res.send(results);
@@ -82,10 +83,10 @@ const getAWSSignedUrl = (bucket, key) => {
   return s3.getSignedUrl('getObject', params);
 };
 
-app.get('/entry/:entryId', (req, res) => {
+app.get('/entry/:entryId', authMiddleware, (req, res) => {
   let query = {};
   query.entryId = req.params.entryId;
-  query.user_id = '123';
+  query.user_id = req.userId;
   database.retrieveEntryMedia(query)
   .then( result => {
     let key = result[0].audio.key;;


### PR DESCRIPTION
Summary:

**Summary**
- Added Firebase-auth middleware and routed entry/job posting APIs through it, removing hardcoded `user_id` usage and enforcing per-user queries. (`server/authMiddleware.js:1`, `server/server.js:47`)
- Scoped job postings to authenticated users and required `user_id` on new posts. (`server/requestHandlers.js:4`, `database/db_helpers.js:7`, `database/models/jobPost.js:4`)

**Config Notes**
- Set `FIREBASE_SERVICE_ACCOUNT` to the JSON service account string, or configure ADC for `firebase-admin`. Authenticated requests must send `Authorization: Bearer <idToken>`.

**Files Touched**
- `server/authMiddleware.js:1`
- `server/server.js:47`
- `server/requestHandlers.js:4`
- `database/db_helpers.js:7`
- `database/models/jobPost.js:4`

**Tests**
- Not run (no test command requested).

Want me to run a quick smoke test or add a small auth header example to the README?